### PR TITLE
Update saving services versions

### DIFF
--- a/bloom-savings-add/build.gradle
+++ b/bloom-savings-add/build.gradle
@@ -1,4 +1,4 @@
-version '1.0.11'
+version '1.0.12'
 
 dependencies {
     implementation project(':bloom-core')

--- a/bloom-savings-get/build.gradle
+++ b/bloom-savings-get/build.gradle
@@ -1,4 +1,4 @@
-version '1.0.3'
+version '1.0.4'
 
 dependencies {
     implementation project(':bloom-core')

--- a/bloom-savings-list/build.gradle
+++ b/bloom-savings-list/build.gradle
@@ -1,4 +1,4 @@
-version '1.0.5'
+version '1.0.6'
 
 dependencies {
     implementation project(':bloom-core')

--- a/bloom-savings-update/build.gradle
+++ b/bloom-savings-update/build.gradle
@@ -1,4 +1,4 @@
-version '1.0.4'
+version '1.0.5'
 
 dependencies {
     implementation project(':bloom-core')


### PR DESCRIPTION
Forgot to bump savings versions in #16.

Because of this the changes made have not been deployed as it detects the artifact file as being the same (due to still having the same name).

This PR will allow savings to have a start amount of 0.00.